### PR TITLE
Enable force destroy for s3 log bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In order to run all checks at any point run the following command:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_logs_bucket"></a> [s3\_logs\_bucket](#module\_s3\_logs\_bucket) | cn-terraform/logs-s3-bucket/aws | 1.0.4 |
+| <a name="module_s3_logs_bucket"></a> [s3\_logs\_bucket](#module\_s3\_logs\_bucket) | cn-terraform/logs-s3-bucket/aws | 1.0.5 |
 
 ## Resources
 
@@ -96,6 +96,7 @@ In order to run all checks at any point run the following command:
 | <a name="input_create_acm_certificate"></a> [create\_acm\_certificate](#input\_create\_acm\_certificate) | Enable or disable automatic ACM certificate creation. If set to false, the variable acm\_certificate\_arn\_to\_use is required. Defaults to true | `bool` | `true` | no |
 | <a name="input_create_route53_hosted_zone"></a> [create\_route53\_hosted\_zone](#input\_create\_route53\_hosted\_zone) | Enable or disable Route 53 hosted zone creation. If set to false, the variable route53\_hosted\_zone\_id is required. Defaults to true | `bool` | `true` | no |
 | <a name="input_is_ipv6_enabled"></a> [is\_ipv6\_enabled](#input\_is\_ipv6\_enabled) | (Optional) - Whether the IPv6 is enabled for the distribution. Defaults to true | `bool` | `true` | no |
+| <a name="input_log_bucket_force_destroy"></a> [log\_bucket\_force\_destroy](#input\_log\_bucket\_force\_destroy) | (Optional, Default:false) A boolean that indicates all objects (including any locked objects) should be deleted from the log bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | <a name="input_log_bucket_versioning_mfa_delete"></a> [log\_bucket\_versioning\_mfa\_delete](#input\_log\_bucket\_versioning\_mfa\_delete) | (Optional) Specifies whether MFA delete is enabled in the bucket versioning configuration. Valid values: Enabled or Disabled. Defaults to Disabled | `string` | `"Disabled"` | no |
 | <a name="input_log_bucket_versioning_status"></a> [log\_bucket\_versioning\_status](#input\_log\_bucket\_versioning\_status) | (Optional) The versioning state of the bucket. Valid values: Enabled or Suspended. Defaults to Enabled | `string` | `"Enabled"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for resources on AWS | `any` | n/a | yes |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,4 +22,6 @@ module "test_website" {
       }
     }
   }
+
+  log_bucket_force_destroy = false
 }

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "s3_logs_bucket" {
   name_prefix                   = "${var.name_prefix}-log-bucket"
   aws_principals_identifiers    = formatlist("arn:aws:iam::%s:root", var.aws_accounts_with_read_view_log_bucket)
   block_s3_bucket_public_access = true
+  s3_bucket_force_destroy       = var.log_bucket_force_destroy
   # enable_s3_bucket_server_side_encryption        = var.enable_s3_bucket_server_side_encryption
   # s3_bucket_server_side_encryption_sse_algorithm = var.s3_bucket_server_side_encryption_sse_algorithm
   # s3_bucket_server_side_encryption_key           = var.s3_bucket_server_side_encryption_key

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "log_bucket_versioning_mfa_delete" {
   default     = "Disabled"
 }
 
+variable "log_bucket_force_destroy" {
+  description = "(Optional, Default:false) A boolean that indicates all objects (including any locked objects) should be deleted from the log bucket so that the bucket can be destroyed without error. These objects are not recoverable."
+  type        = bool
+  default     = false
+}
+
 variable "aws_accounts_with_read_view_log_bucket" {
   description = "List of AWS accounts with read permissions to log bucket"
   type        = list(string)


### PR DESCRIPTION
## Summary
When running `terraform destroy` the S3 buckets need to be empty to properly complete. Force deletion is already supported for the website bucket using `website_bucket_force_destroy = true` but the log bucket will still prevent destruction. The added input will allow configuration for the logging bucket to also be force deleted when it is not empty. 

## Changes
- Create `log_bucket_force_destroy` variable, defaulted to `false`
- Use this to control `s3_bucket_force_destroy` from [cn-terraform/logs-s3-bucket/aws](https://registry.terraform.io/modules/cn-terraform/logs-s3-bucket/aws/latest)

## Notes
This is my first PR to a Terraform module, please let me know if there is anything else that would be needed for these changes. Thanks!