### PR TITLE
Adding ownership controls to the webite bucket

### DIFF
--- a/website.tf
+++ b/website.tf
@@ -78,7 +78,7 @@ resource "aws_s3_bucket_ownership_controls" "website" {
 
 resource "aws_s3_bucket_acl" "website" {
   depends_on = [aws_s3_bucket_ownership_controls.website]
-  provider = aws.main
+  provider   = aws.main
 
   bucket = aws_s3_bucket.website.id
   acl    = var.website_bucket_acl

--- a/website.tf
+++ b/website.tf
@@ -67,7 +67,17 @@ resource "aws_s3_bucket_logging" "website" {
   target_prefix = "website/"
 }
 
+resource "aws_s3_bucket_ownership_controls" "website" {
+  provider = aws.main
+
+  bucket = aws_s3_bucket.website.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "website" {
+  depends_on = [aws_s3_bucket_ownership_controls.website]
   provider = aws.main
 
   bucket = aws_s3_bucket.website.id


### PR DESCRIPTION
setting the ownership controls for the website bucket to "BucketOwnerPreferred" so ACLs can be created on the bucket

This is needed for new buckets based on https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/